### PR TITLE
fix: improve notification mobile layout

### DIFF
--- a/controllers/notificationController.js
+++ b/controllers/notificationController.js
@@ -51,6 +51,7 @@ exports.getManagerNotifications = async (req, res) => {
       layout: 'main',
       page: 'notifications',
       stylesheet: 'notifications',
+      title: 'Notifications',
       user,
       notifications
     });

--- a/public/common/global.css
+++ b/public/common/global.css
@@ -507,4 +507,9 @@ a {
     .mobile-top-bar-button i {
         font-size: var(--icon-size);
     }
+    
+    .event-box-top {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }


### PR DESCRIPTION
Fixed notification layout on mobile as per Emma's comment here: https://jaredlt123.atlassian.net/browse/SCRUM-55?focusedCommentId=10079. Event title and client name are now stacked vertically instead of horizontally in the mobile layout.