### PR TITLE
fix: background color on event details page

### DIFF
--- a/views/eventDetails.hbs
+++ b/views/eventDetails.hbs
@@ -7,7 +7,7 @@
     </button>
     <h2 class="header">Event Details</h2>
 </div>
-    <div class="event-details container">
+    <div class="event-details card">
         {{#if showButtons}}
         <div class="event-controls">
             <button class="bg-button button" id="details-edit-button">


### PR DESCRIPTION
Fixed the event details page not having the full white background color.