### PR TITLE
fix: no gap between cards in past events list

### DIFF
--- a/public/common/javascript/pastEvents.js
+++ b/public/common/javascript/pastEvents.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
-    document.querySelector('.upcoming-events-container').addEventListener('click', function(e) {
+    document.querySelector('.card-list').addEventListener('click', function(e) {
         const eventBox = e.target.closest('.event-box');
         if (!eventBox) return;
         
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     let originalEvents = getInitialEvents();
-    const container = document.querySelector('.upcoming-events-container');
+    const container = document.querySelector('.card-list');
     const noEventsMsg = document.querySelector('.no-events-message');
     
     document.getElementById('eventSearchForm').addEventListener('submit', (e) => {

--- a/views/pastEvents.hbs
+++ b/views/pastEvents.hbs
@@ -7,7 +7,7 @@
     </form>
 </div>
 
-<div class="upcoming-events-container">
+<div class="card-list">
     {{#each events}}
         {{#if (eq status "completed")}}
             {{> eventBox this}}


### PR DESCRIPTION
Fixed a minor bug in the past events page where there are no visual gaps between the cards.