### PR TITLE
fix: remove profile picture from suppliers page

### DIFF
--- a/views/supplier.hbs
+++ b/views/supplier.hbs
@@ -8,7 +8,6 @@
 </div>
 <div class="profile-content">
     <div class="card" id="personalInfo">
-        <div id="profile-picture"></div>
         <div class="personal-info-content">
             <h2>{{supplier.companyName}}</h2>
             <p>Supplier</p>


### PR DESCRIPTION
I forgot to remove the profile picture space from the suppliers page since they don't have that. Addresses this issue: https://jaredlt123.atlassian.net/browse/SCRUM-310